### PR TITLE
Закрыл в docker-compose.yml прямое соединение с MlFlow

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -37,8 +37,6 @@ services:
     restart: always
     build: ./mlflow_image
     image: mlflow_server
-    ports:
-      - "5000:5000"
     networks:
       - postgres
       - mlflow_network


### PR DESCRIPTION
Теперь только через nginx.
Просто убрал проброс портов для сервиса mlflow